### PR TITLE
Add Rakefile with _data processing default

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task :migrate_data_to_templates do
   files.each do |file|
     content = JSON.parse(File.read(file))
     sheets = content.keys
-    sheets.each do |sheet|j
+    sheets.each do |sheet|
       content[sheet].each do |blob|
         if file =~ /Photo Upload/
 

--- a/Rakefile
+++ b/Rakefile
@@ -42,9 +42,11 @@ task :migrate_data_to_templates do
           filepath = File.join(img_dir, filename)
           webpath = File.join(root_path, filename)
           
-          # remote_file_body = Net::HTTP.get(URI(blob["Photo"]))
-
-          # File.write(filepath, remote_file_body)
+          puts "downloading " + blob["Photo"]
+          remote_file_body = Net::HTTP.get(URI(blob["Photo"]))
+          
+          puts "creating " + filepath
+          File.write(filepath, remote_file_body)
 
           # TODO make this an includable thing
           items[project_name] ||= []

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,7 @@
-require 'pry'
 require 'json'
 require 'net/http'
 
 task default: :migrate_data_to_templates
-
-
 
 DATA_DIR = File.expand_path("../_data/", __FILE__)
 desc "Migrate the JSON files located in the data directory into he appropriate project buckets as templates"
@@ -42,11 +39,15 @@ task :migrate_data_to_templates do
           filepath = File.join(img_dir, filename)
           webpath = File.join(root_path, filename)
           
-          puts "downloading " + blob["Photo"]
-          remote_file_body = Net::HTTP.get(URI(blob["Photo"]))
-          
-          puts "creating " + filepath
-          File.write(filepath, remote_file_body)
+          unless File.exist? filepath
+            puts "downloading " + blob["Photo"]
+            remote_file_body = Net::HTTP.get(URI(blob["Photo"]))
+
+            puts "creating " + filepath
+            File.write(filepath, remote_file_body)
+          else
+            puts "#{filepath} already exists, skipping"
+          end
 
           # TODO make this an includable thing
           items[project_name] ||= []

--- a/Rakefile
+++ b/Rakefile
@@ -40,7 +40,7 @@ task :migrate_data_to_templates do
           File.write("./#{filename}", remote_file_body)
 
           # TODO make this an includable thing
-          puts "<img src=\"#{ filepath }\" alt=\"#{blob["Name"]}\" />"
+          puts "<img src=\"#{ filepath }\" title=\"#{blob["Name"]}\" alt=\"#{blob["Name"]}\" />"
         elsif file =~ /Video ID/
           puts '<iframe src="https://player.vimeo.com/video/'+ blob["VimeoID"] + '" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>'
         end

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,50 @@
+require 'pry'
+require 'json'
+require 'net/http'
+
+task default: :migrate_data_to_templates
+
+
+DATA_DIR = File.expand_path("../_data/", __FILE__)
+desc "Migrate the JSON files located in the data directory into he appropriate project buckets as templates"
+task :migrate_data_to_templates do 
+  files = ["Photo Upload.json", "Video ID.json"].map{|f| File.join(DATA_DIR, f)}
+
+  files.each do |file|
+    content = JSON.parse(File.read(file))
+    sheets = content.keys
+    sheets.each do |sheet|j
+      content[sheet].each do |blob|
+        if file =~ /Photo Upload/
+
+          # get the image, put it somewhere
+          remote_filename, extension =  blob["Photo"].split('/')[-1].split('.')
+          
+          filename = [
+                     blob["Project"].downcase.gsub(/[^0-9a-z\-]/, '-'), 
+                     blob["Name"].downcase.gsub(/[^0-9a-z\-]/, '-'),
+                     remote_filename.downcase.gsub(/[^0-9a-z\-_]/, '-')[0,10],
+          ].join('-') + ".#{extension}"
+
+
+
+          #{"Name"=>"Christopher Norris",
+          # "Project"=>"Between Land and Water",
+          # "Photo"=>
+          #"https://apps.cloudstitch.io/alderstudio/__uploads/photo-upload/1517272079025-photo-rPQ2__ybwzmyu6WSjZEd1qJ_.jpg"}
+          
+          # skip if we already have this file synced
+          
+          filepath = filename #TODO find out where to put these
+
+          remote_file_body = Net::HTTP.get(URI(blob["Photo"]))
+
+          File.write("./#{filename}", remote_file_body)
+
+          puts "<img src=\"#{ filepath }\" alt=\"#{blob["Name"]}\" />"
+        elsif file =~ /Video ID/
+        end
+      end
+    end
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -26,8 +26,6 @@ task :migrate_data_to_templates do
                      remote_filename.downcase.gsub(/[^0-9a-z\-_]/, '-')[0,10],
           ].join('-') + ".#{extension}"
 
-
-
           #{"Name"=>"Christopher Norris",
           # "Project"=>"Between Land and Water",
           # "Photo"=>
@@ -41,8 +39,10 @@ task :migrate_data_to_templates do
 
           File.write("./#{filename}", remote_file_body)
 
+          # TODO make this an includable thing
           puts "<img src=\"#{ filepath }\" alt=\"#{blob["Name"]}\" />"
         elsif file =~ /Video ID/
+          puts '<iframe src="https://player.vimeo.com/video/'+ blob["VimeoID"] + '" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>'
         end
       end
     end


### PR DESCRIPTION
This PR contains a `Rakefile` with a default task of `migrate_data_to_templates`.

Run this script by running `rake` or `rake migrate_data_to_templates` from within the project directory. This requires having `ruby` and the `rake` utility installed. Should not require any additional dependencies.

*UNKNOWNS*: We didn't test the `mkdir -p ` command on your mac. should be fine but we can adjust accordingly. 

*KNOWN ISSUES*:

* paths generated from the `_data/*.json` files is screwy because the project name consistency issue. This fix can be achieved in the script or in the form content. Existing rows in the _json and image directories will have the same issue here. Right now the data available gives us project names like `sitetime` instead of `site-time` and `sleeping-babies----social-sculpture`.
* vimeo iframes are not sized properly
* images are not being resized or thumbnailed
* no pagination so huge item collections will just be unbounded